### PR TITLE
Add ExtraMetaData media support (logos & videos)

### DIFF
--- a/src/Configuration/MainMenu.cs
+++ b/src/Configuration/MainMenu.cs
@@ -44,6 +44,24 @@ namespace MAMEUtility.Configuration
                 },
                 new MainMenuItem
                 {
+                    MenuSection = "@" + MAMEUtilityPlugin.PluginName + "|Media",
+                    Description = "Set (extrametadata) videos of selected Games",
+                    Action = (args) => GameMediaManager.setExtraMetaDataOfSelectedGames(GameMediaManager.ExtraMetaDataType.Video)
+                },
+                new MainMenuItem
+                {
+                    MenuSection = "@" + MAMEUtilityPlugin.PluginName + "|Media",
+                    Description = "Set (extrametadata) micro videos of selected Games",
+                    Action = (args) => GameMediaManager.setExtraMetaDataOfSelectedGames(GameMediaManager.ExtraMetaDataType.MicroVideo)
+                },
+                new MainMenuItem
+                {
+                    MenuSection = "@" + MAMEUtilityPlugin.PluginName + "|Media",
+                    Description = "Set (extrametadata) logo of selected Games",
+                    Action = (args) => GameMediaManager.setExtraMetaDataOfSelectedGames(GameMediaManager.ExtraMetaDataType.Logo)
+                },
+                new MainMenuItem
+                {
                     MenuSection = "@" + MAMEUtilityPlugin.PluginName + "|Cataloguer",
                     Description = "Tag selected games",
                     Action = (args) => GameTagger.setTagOfSelectedGames()


### PR DESCRIPTION
Hey,

Your mame addon is really great but i was missing 2 features. I also use extrametadataloader addon from darlinkpower to display logo's and video's of games and mame also has logo's (wheels) and video snapshots so i added support for your addon to import this extrametadata so it can be displayed using darklinkpowers plugin if people use that and want to import it. I tried keeping the logic the same as you had for pictures as that was working fine. The functions to "find" the extrametadata folder along with the functions to grab the file locations needed to save the files are extracted from darklinkpowers plugin, all other code i basically wrote myself. But it is a really simple addition as all that needs to be done is copy the found files to a fixed location per game and i could reuse your image rom / filename mapping todo this.

![image](https://github.com/gerrykeys/playnite-mame-utility/assets/10714776/7a28d1f1-8e90-464c-a1c8-61950628ee67)
